### PR TITLE
Add `nav` as container selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ active focusable item within them using a `data-focus` attribute.
 When a container has no previous focus state, it's first focusable element is
 used instead.
 
-At this time, containers are defined as matching the CSS selectors: `section` or 
-`.lrud-container`.
+At this time, containers are defined as matching the CSS selectors: `nav`, `section` or `.lrud-container`.
 
 ### Block exits
 In some instances, it is desirable to prevent lrud-spatial from selecting another 

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -16,7 +16,7 @@
 
 // Any "interactive content" https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Interactive_content
 const focusableSelector = '[tabindex], a, input, button';
-const containerSelector = 'section, .lrud-container';
+const containerSelector = 'nav, section, .lrud-container';
 
 /**
  * Polyfill for Element API .matches()


### PR DESCRIPTION
Add `nav` as a container selector by default.