### PR TITLE
Add optional chain to container selector

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -158,7 +158,7 @@ export const getNextFocus = (elem, keyCode) => {
     const candidateContainer = getParentContainer(bestCandidate);
 
     if (candidateContainer && candidateContainer !== container) {
-      const blockedExitDirs = (container.getAttribute('data-block-exit') || '').split(' ');
+      const blockedExitDirs = (container?.getAttribute('data-block-exit') || '').split(' ');
       if (blockedExitDirs.indexOf(exitDir) > -1) return;
 
       if (elem.id) container.setAttribute('data-focus', elem.id);


### PR DESCRIPTION
We noticed a bug with spatial when navigating to an item whose parent does not have the data block attributes attached. This PR updates the selector to be optional.