### PR TITLE
do not mutate `Element`, add `matches` helper function

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -19,10 +19,10 @@ const focusableSelector = '[tabindex], a, input, button';
 const containerSelector = 'nav, section, .lrud-container';
 
 /**
- * Polyfill for Element API .matches()
+ * Element API .matches() with fallbacks
  */
-if (!Element.prototype.matches) {
-  Element.prototype.matches =
+const matches = (element, selectors) => {
+  const fn = Element.prototype.matches ||
     Element.prototype.matchesSelector ||
     Element.prototype.mozMatchesSelector ||
     Element.prototype.msMatchesSelector ||
@@ -34,6 +34,8 @@ if (!Element.prototype.matches) {
       while (--i >= 0 && matches.item(i) !== this) {}
       return i > -1;
     };
+  
+  return fn.call(element, selectors);
 }
 
 /**
@@ -45,7 +47,7 @@ if (!Element.prototype.matches) {
 const getParentContainer = (elem) => {
   if (!elem.parentElement || elem.parentElement.tagName === 'BODY') {
     return null;
-  } else if (elem.parentElement.matches(containerSelector)) {
+  } else if (matches(elem.parentElement, containerSelector)) {
     return elem.parentElement;
   }
 


### PR DESCRIPTION
It's better to not mutate globals (unless it's some code that is specifically tasked with polyfilling IMO), so this PR stops polyfilling `Element.prototype.matches` and instead adds a `matches` helper that's used internally.

With the current approach it's possible for unrelated code to accidentally start depending on `Element.matches`, not realising it's there as a side effect of this package being used somewhere, which can be risky as you then get unexpected breakage if LRUD changes in the future, or gets lazy loaded etc