### PR TITLE
Transpile spreads as ES5

### DIFF
--- a/lib/.babelrc
+++ b/lib/.babelrc
@@ -4,6 +4,7 @@
   ],
   "plugins": [
     ["@babel/plugin-transform-destructuring", { "loose": true }],
+    ["@babel/plugin-transform-spread", { "loose": true }],
     ["@babel/plugin-transform-modules-commonjs", { "loose": true }]
   ],
   "minified": true,


### PR DESCRIPTION
Set `loose: true` for `@babel/plugin-transform-spread`, making the spread operators compatible with TVs