### PR TITLE
LOVELY-1376: Set document body as default for scope

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -222,7 +222,7 @@ const getBestCandidate = (elem, candidates, exitDir) => {
  * @return {HTMLElement} The element that should receive focus next
  */
 export const getNextFocus = (elem, keyCode, scope) => {
-  if (!scope || !scope.querySelector) scope = document;
+  if (!scope || !scope.querySelector) scope = document.body;
   if (!elem) return scope.querySelector(focusableSelector);
   const exitDir = _keyMap[keyCode];
 


### PR DESCRIPTION
## Context
On some devices navigation would not function, this ocurred in pages that did not pass through a scope to the `findNextFocus` function, this meant the default scope of `document` was being used. The JS on the affected devices did not support `.contains` on the document type.

## Changes
- Set default scope to `document.body` instead of `document` in `findNextFocus`