### PR TITLE
Ignore previous active child if it doesn't exist

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -281,11 +281,9 @@ export const getNextFocus = (elem, keyCode, scope) => {
         // are already nested in
         if (elem.id) container?.setAttribute('data-focus', elem.id);
 
-        const lastActiveChild = candidateContainer.getAttribute('data-focus');
+        const lastActiveChild = document.getElementById(candidateContainer.getAttribute('data-focus'));
 
-        return lastActiveChild
-          ? document.getElementById(lastActiveChild)
-          : getFocusables(candidateContainer)?.[0];
+        return lastActiveChild || getFocusables(candidateContainer)?.[0];
       }
     }
   }

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -582,4 +582,30 @@ describe('LRUD spatial', () => {
       });
     });
   });
+
+  describe('Last active child', () => {
+    beforeEach(async () => {
+      await page.goto(`${testPath}/2c-v-11f-size.html`);
+      await page.waitForFunction('document.activeElement');
+    });
+
+    it('should return to the last active child when re-entering a container', async () => {
+      await page.evaluate(() => document.getElementById('item-7').focus());
+      await page.keyboard.press('ArrowDown');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-8');
+
+      await page.keyboard.press('ArrowUp');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-7');
+    });
+
+    it('should focus the containers first child if the last active child no longer exists', async () => {
+      await page.evaluate(() => document.getElementById('item-7').focus());
+      await page.keyboard.press('ArrowDown');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-8');
+      await page.evaluate(() => document.getElementById('item-7').remove());
+
+      await page.keyboard.press('ArrowUp');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-1');
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On moving into a container, if there's a `data-focus`, only move to it if the element exists. Otherwise go to the first item, which is the default behaviour.
 
## Motivation and Context
Fixes a current bug. If you leave a container, then remove the item you left from, you'll never be able to re-enter that container as lrud will always try to focus the `data-focus` ID.

## How Has This Been Tested?
New integration tests, plus the dev server

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
