### PR TITLE
Consider valid candidates with overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ following CSS selectors:
 
 Any potential candidate with the `lrud-ignore` class, or inside any parent with the `lrud-ignore` class, will not be considered focusable and will be skipped over. By default LRUD will not ignore candidates that have `opacity: 0` or have a parent with `opacity: 0`, so this class can be used for that.
 
+### Focusable Overlap
+
+By default, LRUD will measure to all candidates that are in the direction to move. It will also include candidates that overlap the current focus by up to 30%, allowing for e.g. a 'right' movement to include something that is above the current focus, but has half of it's size expanding to the right.
+
+This threshold can be adjusted on a per-element basis with the `data-lrud-allowed-overlap` attribute, as a float from 0.0 to 1.0. An overlap of 0.0 will make a candidate only be considered if it is located _entirely_ in the direction of movement.
+
 ## Containers
 
 Focusables can be wrapped in containers. Containers can keep track of the last

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Any potential candidate with the `lrud-ignore` class, or inside any parent with 
 
 By default, LRUD will measure to all candidates that are in the direction to move. It will also include candidates that overlap the current focus by up to 30%, allowing for e.g. a 'right' movement to include something that is above the current focus, but has half of it's size expanding to the right.
 
-This threshold can be adjusted on a per-element basis with the `data-lrud-allowed-overlap` attribute, as a float from 0.0 to 1.0. An overlap of 0.0 will make a candidate only be considered if it is located _entirely_ in the direction of movement.
+This threshold can be adjusted on a per-element basis with the `data-lrud-overlap-threshold` attribute, as a float from 0.0 to 1.0. An overlap of 0.0 will make a candidate only be considered if it is located _entirely_ in the direction of movement.
 
 ## Containers
 

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -217,27 +217,26 @@ const getBlockedExitDirs = (container, candidateContainer) => {
  * Check if all the candidate's corners are past the midpoint of the item we're leaving,
  * and at least one corner is beyond the edge we're leaving.
  *
- * @param {Object} exitMiddle The centre point of the rectangle we're leaving
  * @param {Object} entryRect An object representing the rectangle of the item we're moving to
  * @param {String} exitDir The direction we're moving in
  * @param {Object} exitPoint The midpoint of the edge we're leaving
+ * @param {Float} entryWeighting Percentage of the candidate that is allowed to be behind the target
  * @return {Booelan} true if candidate is in the correct dir, false if not
  */
-const isValidCandidate = (exitMiddle, entryRect, exitDir, exitPoint) => {
+const isValidCandidate = (entryRect, exitDir, exitPoint, entryWeighting) => {
   if (entryRect.width === 0 && entryRect.height === 0) return false;
+  if (!entryWeighting && entryWeighting != 0) entryWeighting = 0.3;
 
-  const corners = [
-    { x: entryRect.left, y: entryRect.top },
-    { x: entryRect.right, y: entryRect.top },
-    { x: entryRect.right, y: entryRect.bottom },
-    { x: entryRect.left, y: entryRect.bottom }
-  ];
+  const weightedEntryPoint = {
+    x: entryRect.x + (entryRect.width * (exitDir === 'left' ? 1 - entryWeighting : exitDir === 'right' ? entryWeighting : 0.5)),
+    y: entryRect.y + (entryRect.height * (exitDir === 'up' ? 1 - entryWeighting : exitDir === 'down' ? entryWeighting : 0.5))
+  };
 
   if (
-    exitDir === 'left' && corners.every(corner => isRight(exitMiddle, corner)) && corners.some((corner) => isRight(exitPoint, corner)) ||
-    exitDir === 'right' && corners.every(corner => isRight(corner, exitMiddle)) && corners.some((corner) => isRight(corner, exitPoint)) ||
-    exitDir === 'up' && corners.every(corner => isBelow(exitMiddle, corner)) && corners.some((corner) => isBelow(exitPoint, corner)) ||
-    exitDir === 'down' && corners.every(corner => isBelow(corner, exitMiddle)) && corners.some((corner) => isBelow(corner, exitPoint))
+    exitDir === 'left' && isRight(exitPoint, weightedEntryPoint) ||
+    exitDir === 'right' && isRight(weightedEntryPoint, exitPoint) ||
+    exitDir === 'up' && isBelow(exitPoint, weightedEntryPoint) ||
+    exitDir === 'down' && isBelow(weightedEntryPoint, exitPoint)
   ) return true;
 
   return false;
@@ -248,17 +247,14 @@ const getBestCandidate = (elem, candidates, exitDir) => {
   let bestDistance = Infinity;
   const exitRect = elem.getBoundingClientRect();
   const exitPoint = getMidpointForEdge(exitRect, exitDir);
-  const exitMiddle = {
-    x: exitRect.x + (exitRect.width / 2),
-    y: exitRect.y + (exitRect.height / 2)
-  };
 
   for (let i = 0; i < candidates.length; ++i) {
     const candidate = candidates[i];
     const entryRect = candidate.getBoundingClientRect();
 
     // Bail if the candidate is in the opposite direction or has no dimensions
-    if (!isValidCandidate(exitMiddle, entryRect, exitDir, exitPoint)) continue;
+    const allowedOverlap = parseFloat(candidate.getAttribute('data-lrud-allowed-overlap'));
+    if (!isValidCandidate(entryRect, exitDir, exitPoint, allowedOverlap)) continue;
 
     const nearestPoint = getNearestPoint(exitPoint, exitDir, entryRect);
     const distance = getDistanceBetweenPoints(exitPoint, nearestPoint);
@@ -280,6 +276,7 @@ const getBestCandidate = (elem, candidates, exitDir) => {
  * @return {HTMLElement} The element that should receive focus next
  */
 export const getNextFocus = (elem, keyCode, scope) => {
+  window?.drawLines?.();
   if (!scope || !scope.querySelector) scope = document.body;
   if (!elem) return getFocusables(scope)?.[0];
   const exitDir = _keyMap[keyCode];

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -214,8 +214,8 @@ const getBlockedExitDirs = (container, candidateContainer) => {
 };
 
 /**
- * Check if all the candidate's corners are past the midpoint of the item we're leaving,
- * and at least one corner is beyond the edge we're leaving.
+ * Check if the candidate is in the `exitDir` direction from the rect we're leaving,
+ * with an overlap allowance of entryWeighting as a percentage of the candidate's width.
  *
  * @param {Object} entryRect An object representing the rectangle of the item we're moving to
  * @param {String} exitDir The direction we're moving in

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -253,7 +253,7 @@ const getBestCandidate = (elem, candidates, exitDir) => {
     const entryRect = candidate.getBoundingClientRect();
 
     // Bail if the candidate is in the opposite direction or has no dimensions
-    const allowedOverlap = parseFloat(candidate.getAttribute('data-lrud-allowed-overlap'));
+    const allowedOverlap = parseFloat(candidate.getAttribute('data-lrud-overlap-threshold'));
     if (!isValidCandidate(entryRect, exitDir, exitPoint, allowedOverlap)) continue;
 
     const nearestPoint = getNearestPoint(exitPoint, exitDir, entryRect);

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -214,14 +214,16 @@ const getBlockedExitDirs = (container, candidateContainer) => {
 };
 
 /**
- * Return early if candidate is in the wrong direction
+ * Check if all the candidate's corners are past the midpoint of the item we're leaving,
+ * and at least one corner is beyond the edge we're leaving.
  *
+ * @param {Object} exitMiddle The centre point of the rectangle we're leaving
  * @param {Object} entryRect An object representing the rectangle of the item we're moving to
  * @param {String} exitDir The direction we're moving in
- * @param {Object} exitPoint The first point of the item we're leaving
+ * @param {Object} exitPoint The midpoint of the edge we're leaving
  * @return {Booelan} true if candidate is in the correct dir, false if not
  */
-const isValidCandidate = (entryRect, exitDir, exitPoint) => {
+const isValidCandidate = (exitMiddle, entryRect, exitDir, exitPoint) => {
   if (entryRect.width === 0 && entryRect.height === 0) return false;
 
   const corners = [
@@ -232,10 +234,10 @@ const isValidCandidate = (entryRect, exitDir, exitPoint) => {
   ];
 
   if (
-    exitDir === 'left' && corners.some((corner) => isRight(exitPoint, corner)) ||
-    exitDir === 'right' && corners.some((corner) => isRight(corner, exitPoint)) ||
-    exitDir === 'up' && corners.some((corner) => isBelow(exitPoint, corner)) ||
-    exitDir === 'down' && corners.some((corner) => isBelow(corner, exitPoint))
+    exitDir === 'left' && corners.every(corner => isRight(exitMiddle, corner)) && corners.some((corner) => isRight(exitPoint, corner)) ||
+    exitDir === 'right' && corners.every(corner => isRight(corner, exitMiddle)) && corners.some((corner) => isRight(corner, exitPoint)) ||
+    exitDir === 'up' && corners.every(corner => isBelow(exitMiddle, corner)) && corners.some((corner) => isBelow(exitPoint, corner)) ||
+    exitDir === 'down' && corners.every(corner => isBelow(corner, exitMiddle)) && corners.some((corner) => isBelow(corner, exitPoint))
   ) return true;
 
   return false;
@@ -246,13 +248,17 @@ const getBestCandidate = (elem, candidates, exitDir) => {
   let bestDistance = Infinity;
   const exitRect = elem.getBoundingClientRect();
   const exitPoint = getMidpointForEdge(exitRect, exitDir);
+  const exitMiddle = {
+    x: exitRect.x + (exitRect.width / 2),
+    y: exitRect.y + (exitRect.height / 2)
+  };
 
   for (let i = 0; i < candidates.length; ++i) {
     const candidate = candidates[i];
     const entryRect = candidate.getBoundingClientRect();
 
     // Bail if the candidate is in the opposite direction or has no dimensions
-    if (!isValidCandidate(entryRect, exitDir, exitPoint)) continue;
+    if (!isValidCandidate(exitMiddle, entryRect, exitDir, exitPoint)) continue;
 
     const nearestPoint = getNearestPoint(exitPoint, exitDir, entryRect);
     const distance = getDistanceBetweenPoints(exitPoint, nearestPoint);

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -276,7 +276,6 @@ const getBestCandidate = (elem, candidates, exitDir) => {
  * @return {HTMLElement} The element that should receive focus next
  */
 export const getNextFocus = (elem, keyCode, scope) => {
-  window?.drawLines?.();
   if (!scope || !scope.querySelector) scope = document.body;
   if (!elem) return getFocusables(scope)?.[0];
   const exitDir = _keyMap[keyCode];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build": "rm -f lib/lrud.min.js && babel lib --out-file lib/lrud.min.js",
     "server": "node ./test/server.js",
     "lint": "eslint .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preversion": "npm test",
+    "postversion": "git push origin master --tags --no-verify"
   },
   "repository": {
     "type": "git",

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -498,6 +498,12 @@ describe('LRUD spatial', () => {
       await page.keyboard.press('ArrowRight');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-15');
     });
+
+    it('should not consider items in the direction you want to move if it is behind the exit midpoint ', async () => {
+      await page.evaluate(() => document.getElementById('item-8').focus());
+      await page.keyboard.press('ArrowRight');
+      expect(await page.evaluate(() => document.activeElement.id)).not.toEqual('item-15');
+    });
   });
 
   describe('Scope', () => {

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -492,17 +492,43 @@ describe('LRUD spatial', () => {
       await page.keyboard.press('ArrowDown');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-11');
     });
+  });
 
-    it('should consider items in the direction you want to move even if some of that items area is in the opposite direction', async () => {
+  describe('Candidate overlap', () => {
+    beforeEach(async () => {
+      await page.goto(`${testPath}/tiled-items.html`);
+      await page.waitForFunction('document.activeElement');
+    });
+
+    it('should consider items in the direction you want to move if they are fully in that direction with no overlap', async () => {
+      await page.evaluate(() => document.getElementById('item-36').focus());
+      await page.keyboard.press('ArrowRight');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-44');
+    });
+
+    it('should consider items in the direction you want to move if they overlap by up to 30%', async () => {
       await page.evaluate(() => document.getElementById('item-22').focus());
       await page.keyboard.press('ArrowRight');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-15');
     });
 
-    it('should not consider items in the direction you want to move if it is behind the exit midpoint ', async () => {
-      await page.evaluate(() => document.getElementById('item-8').focus());
+    it('should not consider items in the direction you want to move if they overlap by more than 30%', async () => {
+      await page.evaluate(() => document.getElementById('item-29').focus());
       await page.keyboard.press('ArrowRight');
       expect(await page.evaluate(() => document.activeElement.id)).not.toEqual('item-15');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-8');
+    });
+
+    it('should consider items with a customised overlap value', async () => {
+      await page.evaluate(() => document.getElementById('item-44').setAttribute('data-lrud-allowed-overlap', 0.6));
+      await page.evaluate(() => document.getElementById('item-29').focus());
+      await page.keyboard.press('ArrowRight');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-44');
+
+      await page.evaluate(() => document.getElementById('item-15').setAttribute('data-lrud-allowed-overlap', 0));
+      await page.evaluate(() => document.getElementById('item-22').focus());
+      await page.keyboard.press('ArrowRight');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-8');
     });
   });
 

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -520,12 +520,12 @@ describe('LRUD spatial', () => {
     });
 
     it('should consider items with a customised overlap value', async () => {
-      await page.evaluate(() => document.getElementById('item-44').setAttribute('data-lrud-allowed-overlap', 0.6));
+      await page.evaluate(() => document.getElementById('item-44').setAttribute('data-lrud-overlap-threshold', 0.6));
       await page.evaluate(() => document.getElementById('item-29').focus());
       await page.keyboard.press('ArrowRight');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-44');
 
-      await page.evaluate(() => document.getElementById('item-15').setAttribute('data-lrud-allowed-overlap', 0));
+      await page.evaluate(() => document.getElementById('item-15').setAttribute('data-lrud-overlap-threshold', 0));
       await page.evaluate(() => document.getElementById('item-22').focus());
       await page.keyboard.press('ArrowRight');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-8');

--- a/test/template.html
+++ b/test/template.html
@@ -31,7 +31,7 @@
         };
         const distance = ([a, b]) => Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2))
         window.drawLines = () => {
-            ctx.clearRect(0, 0, canvas.width, canvas.height)
+            window.clear()
             lines.sort((a, b) => distance(a) - distance(b))
             if(!lines) return
             const bestLine = lines.shift()
@@ -41,6 +41,16 @@
         }
         window.addLine = (pointA, pointB) => {
             lines.push([pointA, pointB])
+        }
+        window.drawDot = (point, colour = 'red') => {
+            if(!document.getElementById('lines').checked) return
+            ctx.beginPath();
+            ctx.arc(point.x, point.y, 3, 0, 2 * Math.PI, false);
+            ctx.fillStyle = colour;
+            ctx.fill();
+        }
+        window.clear = () => {
+            ctx.clearRect(0, 0, canvas.width, canvas.height)
         }
     </script>
 </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Reverting the logic of valid candidates again slightly, to consider how much a candidate overlaps the current focus, and allow for a small amount of overlap in each direction.
- Added an attribute to allow customising that threshold.
- Removed the corner checking logic in favour of this approach, as the corner checking didn't handle all the scenarios in the way we'd expect, and lack of customisation made it too stubborn.
    - Primarily it considered stuff 'to the right' even if it stuck out by a single pixel. Technically correct, but visually weird and unintuitive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Here, going right from 1 would originally not go anywhere, as the target edge of 2 & 3 (their left edge) is left of the exit edge (right edge of 1).
<img width="468" alt="image" src="https://github.com/bbc/lrud-spatial/assets/7268569/340289b9-231a-4885-8b18-d0e17d9bfcff">

However sometimes we want to be able to consider items that are 'right-ish' from the current focus, even if they are also offset in a different direction. So even though 3 is below 1 and therefore a valid 'down' candidate, it is offset enough to be the right that it should be a 'right' candidate too.

With this change, the target edge is effectively moved by a small amount, allowing for the actual edge of the candidate to overlap the current focus. Here the new lines represent the adjusted edges of each container. 3's adjusted edge is now to the right of 1's right edge, so it's considered a valid 'right' candidate from 1.
<img width="468" alt="image" src="https://github.com/bbc/lrud-spatial/assets/7268569/775b56bc-6391-4672-899f-2f6480349490">

By default, the edge is moved by 30% of the element's width/height - effectively allowing for up to 30% of the candidate to overlap with the current focus.

The `data-lrud-overlap-threshold` attribute allows for tweaking that threshold on a per-element basis. It takes a float from 0.0 to 1.0, representing the percentage of the element that can overlap and still be a valid candidate. The default overlap is 0.3, 30%.

Here item 3's allowed overlap is `0.1` (10% of its width), so it is no longer valid. A value of 0 would return to the original behaviour and only consider candidates that don't overlap at all as valid.
<img width="468" alt="image" src="https://github.com/bbc/lrud-spatial/assets/7268569/e691cc50-9853-4e98-9ebd-96873fbc9d16">


## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
New integration tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
