### PR TITLE
Don't stop `npm install` if Husky fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "rm -f lib/lrud.min.js && babel lib --out-file lib/lrud.min.js",
     "server": "node ./test/server.js",
     "lint": "eslint .",
-    "prepare": "husky install",
+    "prepare": "husky install || exit 0",
     "preversion": "npm test",
     "postversion": "git push origin master --tags --no-verify"
   },


### PR DESCRIPTION
## Description
Likely due to not being at the root of the repo, for example if being installed in a subproject of a monorepo

## Motivation and Context
Fixes #29; this was causing issues trying to use the new version in EPT. Similar approach for this problem used in BSP: https://github.com/bbc/bigscreen-player/blob/master/package.json#L15

## How Has This Been Tested?
Ran `npm install` in and outside of a repo context (Deleted `.git`), completes successfully in both cases, and Git Hooks are installed inside the repo context.

## Checklist:
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [N/A] I have added tests to cover my changes.
- [x] All new and existing tests passed.
