### PR TITLE
Don't use client bounding rect X/Y values

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -228,8 +228,8 @@ const isValidCandidate = (entryRect, exitDir, exitPoint, entryWeighting) => {
   if (!entryWeighting && entryWeighting != 0) entryWeighting = 0.3;
 
   const weightedEntryPoint = {
-    x: entryRect.x + (entryRect.width * (exitDir === 'left' ? 1 - entryWeighting : exitDir === 'right' ? entryWeighting : 0.5)),
-    y: entryRect.y + (entryRect.height * (exitDir === 'up' ? 1 - entryWeighting : exitDir === 'down' ? entryWeighting : 0.5))
+    x: entryRect.left + (entryRect.width * (exitDir === 'left' ? 1 - entryWeighting : exitDir === 'right' ? entryWeighting : 0.5)),
+    y: entryRect.top + (entryRect.height * (exitDir === 'up' ? 1 - entryWeighting : exitDir === 'down' ? entryWeighting : 0.5))
   };
 
   if (


### PR DESCRIPTION
## Description
Replacing the use of `Element.getBoundingClientRect`'s x and y values with left and top. They're always the same number.

## Motivation and Context
On some old browsers, the x and y properties don't exist. We've polyfilled to fix it in most cases, but this change means the library works everywhere out the box again, without relying on polyfills.

## How Has This Been Tested?
No functionality change, all tests are still passing. Will verify it on some broken devices.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
