### PR TITLE
Always update focus on moving inside a container

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -317,6 +317,8 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
     const isNestedContainer = parentContainer?.contains(candidateContainer);
     const isAnscestorContainer = candidateContainer?.contains(parentContainer);
 
+    if (elem.id) parentContainer?.setAttribute('data-focus', elem.id);
+
     if (!isCurrentContainer && (!isNestedContainer || isBestCandidateAContainer)) {
       const blockedExitDirs = getBlockedExitDirs(parentContainer, candidateContainer);
       if (blockedExitDirs.indexOf(exitDir) > -1) return;
@@ -324,8 +326,6 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
       if (candidateContainer && !isAnscestorContainer) {
         // Ignore active child behaviour when moving into a container that we
         // are already nested in
-        if (elem.id) parentContainer?.setAttribute('data-focus', elem.id);
-
         const lastActiveChild = document.getElementById(candidateContainer.getAttribute('data-focus'));
 
         return lastActiveChild || getFocusables(candidateContainer)?.[0];
@@ -333,6 +333,7 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
     }
   }
 
+  if (bestCandidate?.id) parentContainer?.setAttribute('data-focus', bestCandidate.id);
   return bestCandidate;
 };
 

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -667,5 +667,16 @@ describe('LRUD spatial', () => {
       await page.keyboard.press('ArrowUp');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-1');
     });
+
+    it('should still remember last active child if focus is manually moved from a container', async () => {
+      await page.evaluate(() => document.getElementById('item-1').focus());
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowRight');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-6');
+      await page.evaluate(() => document.getElementById('item-8').focus());
+
+      await page.keyboard.press('ArrowUp');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-6');
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating the `data-focus` attribute every time focus moves inside a container, rather than only setting it once when focus moves out of the container.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes the scenario where focus is moved out of a container by any other JS that's not lrud (or a user input), and it 'forgets' what the active child was because it never got saved.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
New integration test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
