### PR TITLE
Fix data-focus for nested containers

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -317,7 +317,9 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
     const isNestedContainer = parentContainer?.contains(candidateContainer);
     const isAnscestorContainer = candidateContainer?.contains(parentContainer);
 
-    if (elem.id) parentContainer?.setAttribute('data-focus', elem.id);
+    const candidateActiveChild = candidateContainer?.getAttribute('data-focus');
+    parentContainer?.setAttribute('data-focus', elem.id);
+    candidateContainer?.setAttribute('data-focus', bestCandidate.id);
 
     if (!isCurrentContainer && (!isNestedContainer || isBestCandidateAContainer)) {
       const blockedExitDirs = getBlockedExitDirs(parentContainer, candidateContainer);
@@ -326,14 +328,15 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
       if (candidateContainer && !isAnscestorContainer) {
         // Ignore active child behaviour when moving into a container that we
         // are already nested in
-        const lastActiveChild = document.getElementById(candidateContainer.getAttribute('data-focus'));
+        const lastActiveChild = document.getElementById(candidateActiveChild);
 
-        return lastActiveChild || getFocusables(candidateContainer)?.[0];
+        const newFocus = lastActiveChild || getFocusables(candidateContainer)?.[0];
+        candidateContainer?.setAttribute('data-focus', newFocus?.id);
+        return newFocus;
       }
     }
   }
 
-  if (bestCandidate?.id) parentContainer?.setAttribute('data-focus', bestCandidate.id);
   return bestCandidate;
 };
 

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -678,5 +678,25 @@ describe('LRUD spatial', () => {
       await page.keyboard.press('ArrowUp');
       expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-6');
     });
+
+    it('should only store the last active child ID if the child is not inside another container', async () => {
+      const getParentContainerDataFocus = (id) => page.evaluate((id) => document.getElementById(id).parentElement.getAttribute('data-focus'), id);
+      await page.goto(`${testPath}/4c-v-5f-nested.html`);
+      await page.evaluate(() => document.getElementById('item-1').focus());
+      await page.keyboard.press('ArrowDown');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-2');
+      expect(await getParentContainerDataFocus('item-1')).toEqual('item-1');
+      expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+      await page.keyboard.press('ArrowDown');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-3');
+      expect(await getParentContainerDataFocus('item-1')).toEqual('item-3');
+      expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+      await page.keyboard.press('ArrowUp');
+      expect(await getParentContainerDataFocus('item-1')).toEqual('item-3');
+      expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+      await page.keyboard.press('ArrowUp');
+      expect(await getParentContainerDataFocus('item-1')).toEqual('item-1');
+      expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating the logic for where `data-focus` gets set

- Always save the element we're _leaving_'s ID on its parent container
- Always save the new best candidate's ID on the new candidate container
- (If these are the same container, the best candidate overwrites it)
- Store any existing data-focus before doing that, as we still need to use the old value if it existed, not necessarily always the bestCandidate. Then update it if we did have to use it.

## Motivation and Context
Last change (#37) was intended to save the data-focus value on every internal move rather than only when leaving a container, so that if focus was moved away for any reason then the data-focus would still be preserved.

That change missed the case of nested containers, so it would store the ID of the inner element on the outer container, not it's _actual_ parent container. Container data-focus should only ever be the ID of a child that belongs to a container.

It also missed that when moving _in_ to a nested container, it should save the data-focus - rather than only when moving between the children of the container. New implementation always makes sure to save the ID moved from and the ID moved to, on every move. 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
New integration test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
