### PR TITLE
Run tests with existing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ To investigate why a test is failing, or just to hack on some changes... run
 `npm run server`. Then go to [http://localhost:3005](http://localhost:3005) and
 select a layout.
 
-> Remember to terminate this process before running the tests again!
-
 ## Contact
 
 [TVOpenSource@bbc.co.uk](mailto:TVOpenSource@bbc.co.uk) - we aim to respond to emails within a week.

--- a/package-lock.json
+++ b/package-lock.json
@@ -282,15 +282,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/@babel/core/node_modules/caniuse-lite": {
-      "version": "1.0.30001305",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
-      "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/@babel/core/node_modules/electron-to-chromium": {
       "version": "1.4.61",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
@@ -2788,9 +2779,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
+      "version": "1.0.30001580",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+      "integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2799,6 +2790,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -7382,11 +7377,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001305",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
-          "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA=="
-        },
         "electron-to-chromium": {
           "version": "1.4.61",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
@@ -9359,9 +9349,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g=="
+      "version": "1.0.30001580",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+      "integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA=="
     },
     "chalk": {
       "version": "4.1.2",

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -9,7 +9,13 @@ describe('LRUD spatial', () => {
   let context;
 
   beforeAll(async () => {
-    await server.listen();
+    try {
+      await server.listen();
+    } catch (ex) {
+      if (ex.code !== 'EADDRINUSE') {
+        throw ex;
+      }
+    }
     browser = await puppeteer.launch({
       defaultViewport: {width: 1280, height: 800}
     });
@@ -21,13 +27,15 @@ describe('LRUD spatial', () => {
   });
 
   afterEach(async () => {
-    await page.close();
+    await page?.close();
   });
 
   afterAll(async () => {
-    await context.close();
-    await browser.close();
-    await server.close();
+    await context?.close();
+    await browser?.close();
+    try {
+      await server.close();
+    } catch { /* empty */ }
   });
 
   describe('Initialising', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow running the integration tests with an existing test server running, rather than always trying to start a new one. Will still start it if there's not one running, but won't fail if it can't start because the port is already in use.

Also ran `npx update-browserslist-db` to quiet that error message, so package-lock has updated.

## Motivation and Context
Currently if you've got the dev server running, you have to stop it again to run the tests.

## How Has This Been Tested?
Running the tests with and without the server

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
