### PR TITLE
Fix data-focus updating when exit is blocked

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -291,6 +291,9 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
 
   // Get parent focus container
   const parentContainer = getParentContainer(elem);
+  if (parentContainer && matches(elem, focusableSelector)) {
+    parentContainer.setAttribute('data-focus', elem.id);
+  }
 
   let bestCandidate;
 
@@ -317,10 +320,6 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
     const isNestedContainer = parentContainer?.contains(candidateContainer);
     const isAnscestorContainer = candidateContainer?.contains(parentContainer);
 
-    const candidateActiveChild = candidateContainer?.getAttribute('data-focus');
-    parentContainer?.setAttribute('data-focus', elem.id);
-    candidateContainer?.setAttribute('data-focus', bestCandidate.id);
-
     if (!isCurrentContainer && (!isNestedContainer || isBestCandidateAContainer)) {
       const blockedExitDirs = getBlockedExitDirs(parentContainer, candidateContainer);
       if (blockedExitDirs.indexOf(exitDir) > -1) return;
@@ -328,13 +327,15 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
       if (candidateContainer && !isAnscestorContainer) {
         // Ignore active child behaviour when moving into a container that we
         // are already nested in
-        const lastActiveChild = document.getElementById(candidateActiveChild);
+        const lastActiveChild = document.getElementById(candidateContainer?.getAttribute('data-focus'));
 
         const newFocus = lastActiveChild || getFocusables(candidateContainer)?.[0];
         candidateContainer?.setAttribute('data-focus', newFocus?.id);
         return newFocus;
       }
     }
+
+    candidateContainer?.setAttribute('data-focus', bestCandidate.id);
   }
 
   return bestCandidate;

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -8,6 +8,8 @@ describe('LRUD spatial', () => {
   let page;
   let context;
 
+  const getParentContainerDataFocus = (id) => page.evaluate((id) => document.getElementById(id).parentElement.getAttribute('data-focus'), id);
+
   beforeAll(async () => {
     try {
       await server.listen();
@@ -688,7 +690,6 @@ describe('LRUD spatial', () => {
     });
 
     it('should only store the last active child ID if the child is not inside another container', async () => {
-      const getParentContainerDataFocus = (id) => page.evaluate((id) => document.getElementById(id).parentElement.getAttribute('data-focus'), id);
       await page.goto(`${testPath}/4c-v-5f-nested.html`);
       await page.evaluate(() => document.getElementById('item-1').focus());
       await page.keyboard.press('ArrowDown');
@@ -705,6 +706,15 @@ describe('LRUD spatial', () => {
       await page.keyboard.press('ArrowUp');
       expect(await getParentContainerDataFocus('item-1')).toEqual('item-1');
       expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+    });
+
+    it('does not update the new active child ID if the exit was blocked', async () => {
+      await page.goto(`${testPath}/3c-h-6f-blocked-exit.html`);
+      await page.evaluate(() => document.getElementById('item-2').focus());
+      await page.keyboard.press('ArrowDown');
+      expect(await getParentContainerDataFocus('item-2')).toEqual('item-2');
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual('item-2');
+      expect(await getParentContainerDataFocus('item-3')).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactoring how `data-focus` is applied again. Previous fix in #38 still wasn't quite right, as it changed the attributes before the blocked exit checks happen.

- Moved the storing of the element we're leaving higher up
    - Mostly for clarity and to decouple it from bestCandidate logic
    - Also now checks that `elem` is actually a focusable, so it doesn't store IDs of containers or potentially any element that's been passed in
 - Moved the updating of the candidate container to after the between-container movement logic has happened
     - Doesn't have to worry about overwriting the old value before it's needed
     - Happens after data-block-exit has been checked 

## Motivation and Context
Fixes a bug where if movement into a new container is blocked by `data-block-exit`, it still gets its data-focus modified to the candidate that it was going to try to move to. The focus should only update when it actually moves.

## How Has This Been Tested?
Existing data-focus tests still pass, added a new test for this specific behaviour. Checked that it fails on master, passes on this branch.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
