### PR TITLE
Try next candidates after blocking exits

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -243,37 +243,31 @@ const isValidCandidate = (entryRect, exitDir, exitPoint, entryWeighting) => {
 };
 
 /**
- * Get the closest spatial candidate
+ * Sort the candidates ordered by distance to the elem,
+ * and filter out invalid candidates.
  *
  * @param {HTMLElement} elem The search origin
- * @param {HTMLElement[]} candidates An set of candidate elements to assess
  * @param {string} exitDir The direction in which we exited the elem (left, right, up, down)
- * @return {HTMLElement|null} The element that was spatially closest elem in candidates
+ * @param {HTMLElement[]} candidates An set of candidate elements to sort
+ * @return {HTMLElement[]} The candidates array, in order by distance
  */
-const getBestCandidate = (elem, candidates, exitDir) => {
-  let bestCandidate = null;
-  let bestDistance = Infinity;
+const sortValidCandidates = (elem, exitDir, candidates) => {
   const exitRect = elem.getBoundingClientRect();
   const exitPoint = getMidpointForEdge(exitRect, exitDir);
-
-  for (let i = 0; i < candidates.length; ++i) {
-    const candidate = candidates[i];
+  return candidates.filter(candidate => {
+    // Filter out candidates that are in the opposite direction or have no dimensions
     const entryRect = candidate.getBoundingClientRect();
-
-    // Bail if the candidate is in the opposite direction or has no dimensions
     const allowedOverlap = parseFloat(candidate.getAttribute('data-lrud-overlap-threshold'));
-    if (!isValidCandidate(entryRect, exitDir, exitPoint, allowedOverlap)) continue;
-
+    return isValidCandidate(entryRect, exitDir, exitPoint, allowedOverlap);
+  }).map(candidate => {
+    const entryRect = candidate.getBoundingClientRect();
     const nearestPoint = getNearestPoint(exitPoint, exitDir, entryRect);
     const distance = getDistanceBetweenPoints(exitPoint, nearestPoint);
-
-    if (bestDistance > distance) {
-      bestDistance = distance;
-      bestCandidate = candidate;
-    }
-  }
-
-  return bestCandidate;
+    return {
+      candidate,
+      distance
+    };
+  }).sort((a, b) => a.distance - b.distance).map(({ candidate }) => candidate);
 };
 
 /**
@@ -295,26 +289,26 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
     parentContainer.setAttribute('data-focus', elem.id);
   }
 
-  let bestCandidate;
+  let focusableCandidates = [];
 
   // Get all siblings within a prioritised container
   if (parentContainer?.getAttribute('data-lrud-prioritise-children') !== 'false' && scope.contains(parentContainer)) {
     const focusableSiblings = getFocusables(parentContainer);
-    bestCandidate = getBestCandidate(elem, focusableSiblings, exitDir);
+    focusableCandidates = sortValidCandidates(elem, exitDir, focusableSiblings);
   }
 
-  if (!bestCandidate) {
-    const focusableCandidates = [
+  if (focusableCandidates.length === 0) {
+    focusableCandidates = [
       ...getFocusables(scope),
       ...toArray(scope.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0 && container !== parentContainer)
     ];
 
-    bestCandidate = getBestCandidate(elem, focusableCandidates, exitDir);
+    focusableCandidates = sortValidCandidates(elem, exitDir, focusableCandidates);
   }
 
-  if (bestCandidate) {
-    const isBestCandidateAContainer = matches(bestCandidate, containerSelector);
-    const candidateContainer = isBestCandidateAContainer ? bestCandidate : getParentContainer(bestCandidate);
+  for (const candidate of focusableCandidates) {
+    const isBestCandidateAContainer = matches(candidate, containerSelector);
+    const candidateContainer = isBestCandidateAContainer ? candidate : getParentContainer(candidate);
 
     const isCurrentContainer = candidateContainer === parentContainer;
     const isNestedContainer = parentContainer?.contains(candidateContainer);
@@ -322,7 +316,7 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
 
     if (!isCurrentContainer && (!isNestedContainer || isBestCandidateAContainer)) {
       const blockedExitDirs = getBlockedExitDirs(parentContainer, candidateContainer);
-      if (blockedExitDirs.indexOf(exitDir) > -1) return;
+      if (blockedExitDirs.indexOf(exitDir) > -1) continue;
 
       if (candidateContainer && !isAnscestorContainer) {
         // Ignore active child behaviour when moving into a container that we
@@ -335,10 +329,9 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
       }
     }
 
-    candidateContainer?.setAttribute('data-focus', bestCandidate.id);
+    candidateContainer?.setAttribute('data-focus', candidate.id);
+    return candidate;
   }
-
-  return bestCandidate;
 };
 
 const _left = 'left', _right = 'right', _up = 'up', _down = 'down';

--- a/test/layouts/3c-h-6f-blocked-exit.html
+++ b/test/layouts/3c-h-6f-blocked-exit.html
@@ -1,16 +1,35 @@
 
 <h1>Test file with 2 blocked exit sections in horizontal layout with 6 candidates</h1>
-<div class="lrud-container  panel" data-block-exit="down">
-    <a id="item-1" class="item" href="">
-        <h2>1</h2>
-    </a>
+<section style="width: 548px" data-block-exit="up">
+    <section>
+        <section class="panel" data-block-exit="down">
+            <a id="item-1" class="item" href="">
+                <h2>1</h2>
+            </a>
 
-    <a id="item-2"  class="item" href="">
-        <h2>2</h2>
-    </a>
-</div>
+            <a id="item-2"  class="item" href="">
+                <h2>2</h2>
+            </a>
+        </section>
+    </section>
 
-<div class="lrud-container panel vert-offset" data-block-exit="up">
+    <a class="item" href="" style="position: absolute; left: 300px;"></a>
+
+
+    <section class="panel vert-offset">
+        <section>
+            <a id="item-5" class="item" href="">
+                <h2>5</h2>
+            </a>
+
+            <a id="item-6"  class="item" href="">
+                <h2>6</h2>
+            </a>
+        </section>
+    </section>
+</section>
+
+<section class="panel" data-block-exit="up" style="position: absolute; left: 600px; top: 280px">
     <a id="item-3" class="item" href="">
         <h2>3</h2>
     </a>
@@ -18,14 +37,4 @@
     <a id="item-4"  class="item" href="">
         <h2>4</h2>
     </a>
-</div>
-
-<div class="lrud-container panel">
-    <a id="item-5" class="item" href="">
-        <h2>5</h2>
-    </a>
-
-    <a id="item-6"  class="item" href="">
-        <h2>6</h2>
-    </a>
-</div>
+</section>

--- a/test/layouts/3c-h-6f-blocked-exit.html
+++ b/test/layouts/3c-h-6f-blocked-exit.html
@@ -13,9 +13,6 @@
         </section>
     </section>
 
-    <a class="item" href="" style="position: absolute; left: 300px;"></a>
-
-
     <section class="panel vert-offset">
         <section>
             <a id="item-5" class="item" href="">

--- a/test/layouts/styles.css
+++ b/test/layouts/styles.css
@@ -5,6 +5,7 @@
 
 body {
     color: #333;
+    width: 1200px;
     padding:15px;
     background-color: aliceblue;
     overscroll-behavior: none;

--- a/test/layouts/styles.css
+++ b/test/layouts/styles.css
@@ -23,6 +23,16 @@ section > section, .lrud-container > .lrud-container {
     margin: 10px;
 }
 
+section > section > section, .lrud-container > .lrud-container > .lrud-container {
+    background-color: #5b7084;
+    margin: 10px;
+}
+
+section > section > section > section, .lrud-container > .lrud-container > .lrud-container > .lrud-container {
+    background-color: #879db2;
+    margin: 10px;
+}
+
 a {
     text-decoration: none;
     display:inline-block;

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -422,6 +422,16 @@ describe('LRUD spatial', () => {
 
       expect(result).toEqual('item-5');
     });
+
+    it('should move to the second best candidate if first was blocked', async () => {
+      await page.goto(`${testPath}/3c-h-6f-blocked-exit.html`);
+      await page.evaluate(() => document.getElementById('item-6').focus());
+      await page.keyboard.press('ArrowUp');
+
+      const result = await page.evaluate(() => document.activeElement.id);
+
+      expect(result).toEqual('item-1');
+    });
   });
 
   describe('Page with nested containers', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactoring to keep all candidates, in priority order, rather than just finding the best one and discarding the rest. Enables us to ignore the best one for any reason, and fallback to the next in the list.

- Change `getBestCandidate` to be `sortValidCandidates`, so it keeps the whole list in distance order
- Refactor the candidate choosing logic to loop through all of them, rather than only checking the first one

## Motivation and Context
Currently, we only check the blocked exits once, after we've picked a best candidate. If the best candidate does get blocked, we return null. This means there might be other good candidates that get ignored if the best one is in a blocked direction. So instead, we want to keep all the candidates in a sorted order, and find the first one that's a valid move.

Fixes a bug where the best candidate might be outside a container behind a blocked exit, but there is another second best candidate that should be chosen instead.

i.e. here, UP from 6 should go to 2, but 3 is a better candidate. Previously it tries to go to 3, sees the blocked exit, then stops completely. Now it will discard 3, and try again successfully to move you to 2.
<img width="415" alt="image" src="https://github.com/bbc/lrud-spatial/assets/7268569/7571d87c-79f0-4648-ba9d-f19a7138583d">


## How Has This Been Tested?
Updated the template file to expose the behaviour, and added an integration test for it

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
