### PR TITLE
Set parent container's data focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ used instead.
 At this time, containers are defined as matching the CSS selectors:
 `nav`, `section` or `.lrud-container`.
 
-Adding attribute `data-lrud-consider-container-distance` on a container will make LRUD also measure distances to that container's boundary, as well as its children. If the container is the closest of all the possible candidates assessed, LRUD will return one of its children - even if they are not necessarily the spatially closest focusable. The above container focus logic will still be used, so if the container has a previous focus state that will be the returned element. This allows for layouts where moving between containers is the desired behaviour, but their individual elements may not be in the correct positions for that. By default LRUD will only consider focusables when measuring, and ignores container positions.
-
 ### Block exits
 
 In some instances, it is desirable to prevent lrud-spatial from selecting another
@@ -76,6 +74,15 @@ E.g.
 ```html
 <div class="lrud-container" data-block-exit="up down">...</div>
 ```
+
+### Focusable Containers
+
+By default, LRUD only measures the distances to focusables and does not consider where their container boundaries are. Adding the attribute `data-lrud-consider-container-distance` to a container will include it in the distance calculations, as well as its children.
+
+If the container is the closest out of all the possible focusables assessed, LRUD will return one of its children - even if they are not necessarily the spatially closest focusable.
+
+The above container focus logic will still be used, and moving into a focusable container will move to its last focused child if there was one, at any level of container depth inside it.
+
 
 ## How does it work?
 

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -330,14 +330,14 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
   }
 
   for (const candidate of focusableCandidates) {
-    const isBestCandidateAContainer = matches(candidate, containerSelector);
-    const candidateContainer = isBestCandidateAContainer ? candidate : getParentContainer(candidate);
+    const candidateIsContainer = matches(candidate, containerSelector);
+    const candidateContainer = candidateIsContainer ? candidate : getParentContainer(candidate);
 
     const isCurrentContainer = candidateContainer === parentContainer;
     const isNestedContainer = parentContainer?.contains(candidateContainer);
     const isAnscestorContainer = candidateContainer?.contains(parentContainer);
 
-    if (!isCurrentContainer && (!isNestedContainer || isBestCandidateAContainer)) {
+    if (!isCurrentContainer && (!isNestedContainer || candidateIsContainer)) {
       const blockedExitDirs = getBlockedExitDirs(parentContainer, candidateContainer);
       if (blockedExitDirs.indexOf(exitDir) > -1) continue;
 
@@ -353,8 +353,10 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
       }
     }
 
-    getParentFocusableContainer(candidateContainer)?.setAttribute('data-focus', candidate.id);
-    candidateContainer?.setAttribute('data-focus', candidate.id);
+    if (!candidateIsContainer) {
+      getParentFocusableContainer(candidateContainer)?.setAttribute('data-focus', candidate.id);
+      candidateContainer?.setAttribute('data-focus', candidate.id);
+    }
     return candidate;
   }
 };

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -313,7 +313,7 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
   const parentContainer = getParentContainer(elem);
   if (parentContainer && matches(elem, focusableSelector)) {
     parentContainer.setAttribute('data-focus', elem.id);
-    getParentFocusableContainer(elem)?.setAttribute('data-focus', elem.id);
+    getParentFocusableContainer(parentContainer)?.setAttribute('data-focus', elem.id);
   }
 
   let focusableCandidates = [];

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -70,7 +70,7 @@ const getParentContainer = (elem) => {
  * discounting any that are ignored or inside an ignored container
  *
  * @param {HTMLElement} scope The element to search inside of
- * @return {Array} Array of valid focusables inside the scope
+ * @return {HTMLElement[]} Array of valid focusables inside the scope
  */
 const getFocusables = (scope) => {
   if (!scope) return [];
@@ -81,6 +81,18 @@ const getFocusables = (scope) => {
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)));
 };
+
+/**
+ * Get all the focusable candidates inside `scope`,
+ * including focusable containers
+ *
+ * @param {HTMLElement} scope The element to search inside of
+ * @return {HTMLElement[]} Array of valid focusables inside the scope
+ */
+const getAllFocusables = (scope) => [
+  ...toArray(scope.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0),
+  ...getFocusables(scope)
+];
 
 /**
  * Build an array of ancestor containers
@@ -246,12 +258,12 @@ const isValidCandidate = (entryRect, exitDir, exitPoint, entryWeighting) => {
  * Sort the candidates ordered by distance to the elem,
  * and filter out invalid candidates.
  *
+ * @param {HTMLElement[]} candidates A set of candidate elements to sort
  * @param {HTMLElement} elem The search origin
  * @param {string} exitDir The direction in which we exited the elem (left, right, up, down)
- * @param {HTMLElement[]} candidates An set of candidate elements to sort
- * @return {HTMLElement[]} The candidates array, in order by distance
+ * @return {HTMLElement[]} The valid candidates, in order by distance
  */
-const sortValidCandidates = (elem, exitDir, candidates) => {
+const sortValidCandidates = (candidates, elem, exitDir) => {
   const exitRect = elem.getBoundingClientRect();
   const exitPoint = getMidpointForEdge(exitRect, exitDir);
   return candidates.filter(candidate => {
@@ -308,20 +320,13 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
 
   // Get all siblings within a prioritised container
   if (parentContainer?.getAttribute('data-lrud-prioritise-children') !== 'false' && scope.contains(parentContainer)) {
-    const focusableSiblings = [
-     ...getFocusables(parentContainer),
-     ...toArray(parentContainer.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0 && container !== parentContainer)
-    ];
-    focusableCandidates = sortValidCandidates(elem, exitDir, focusableSiblings);
+    const focusableSiblings = getAllFocusables(parentContainer);
+    focusableCandidates = sortValidCandidates(focusableSiblings, elem, exitDir);
   }
 
   if (focusableCandidates.length === 0) {
-    focusableCandidates = [
-      ...getFocusables(scope),
-      ...toArray(scope.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0 && container !== parentContainer)
-    ];
-
-    focusableCandidates = sortValidCandidates(elem, exitDir, focusableCandidates);
+    const candidates = getAllFocusables(scope);
+    focusableCandidates = sortValidCandidates(candidates, elem, exitDir);
   }
 
   for (const candidate of focusableCandidates) {

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -276,6 +276,7 @@ const sortValidCandidates = (elem, exitDir, candidates) => {
  * @return {HTMLElement} The container that matches or null
  */
 const getParentFocusableContainer = (startingCandidate) => {
+  if (!startingCandidate) return null;
   do {
     startingCandidate = getParentContainer(startingCandidate);
   } while (startingCandidate && !matches(startingCandidate, focusableContainerSelector));
@@ -300,6 +301,7 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
   const parentContainer = getParentContainer(elem);
   if (parentContainer && matches(elem, focusableSelector)) {
     parentContainer.setAttribute('data-focus', elem.id);
+    getParentFocusableContainer(elem)?.setAttribute('data-focus', elem.id);
   }
 
   let focusableCandidates = [];

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -271,6 +271,19 @@ const sortValidCandidates = (elem, exitDir, candidates) => {
 };
 
 /**
+ * Get the first parent container that matches the focusable candidate selector
+ * @param {HTMLElement} startingCandidate The starting candidate to get the parent container of
+ * @return {HTMLElement} The container that matches or null
+ */
+const getParentFocusableContainer = (startingCandidate) => {
+  do {
+    startingCandidate = getParentContainer(startingCandidate);
+  } while (startingCandidate && !matches(startingCandidate, focusableContainerSelector));
+
+  return startingCandidate;
+};
+
+/**
  * Get the next focus candidate
  *
  * @param {HTMLElement} elem The search origin
@@ -293,7 +306,10 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
 
   // Get all siblings within a prioritised container
   if (parentContainer?.getAttribute('data-lrud-prioritise-children') !== 'false' && scope.contains(parentContainer)) {
-    const focusableSiblings = getFocusables(parentContainer);
+    const focusableSiblings = [
+     ...getFocusables(parentContainer),
+     ...toArray(parentContainer.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0 && container !== parentContainer)
+    ];
     focusableCandidates = sortValidCandidates(elem, exitDir, focusableSiblings);
   }
 
@@ -324,11 +340,13 @@ export const getNextFocus = (elem, keyOrKeyCode, scope) => {
         const lastActiveChild = document.getElementById(candidateContainer?.getAttribute('data-focus'));
 
         const newFocus = lastActiveChild || getFocusables(candidateContainer)?.[0];
+        getParentFocusableContainer(candidateContainer)?.setAttribute('data-focus', newFocus?.id);
         candidateContainer?.setAttribute('data-focus', newFocus?.id);
         return newFocus;
       }
     }
 
+    getParentFocusableContainer(candidateContainer)?.setAttribute('data-focus', candidate.id);
     candidateContainer?.setAttribute('data-focus', candidate.id);
     return candidate;
   }

--- a/test/layouts/4c-v-5f-nested.html
+++ b/test/layouts/4c-v-5f-nested.html
@@ -1,6 +1,6 @@
 
 <h1>Nested containers</h1>
-<section data-block-exit="down">
+<section data-block-exit="down" id="section-1">
     <a id="item-1" class="item" href=""></a>
     <section>
         <a id="item-2" class="item" href=""></a>
@@ -8,7 +8,7 @@
     <a id="item-3" class="item" href=""></a>
 </section>
 
-<section data-block-exit="down right">
+<section data-block-exit="down right" id="section-2">
     <section>
       <section>
         <section data-block-exit="right">
@@ -24,7 +24,7 @@
 
 <a id="item-7" class="item" href=""></a>
 
-<section data-block-exit="down">
+<section data-block-exit="down" id="section-3">
   <section>
     <a id="item-8" class="item" href=""></a>
   </section>

--- a/test/layouts/nested-focusable-containers.html
+++ b/test/layouts/nested-focusable-containers.html
@@ -1,0 +1,59 @@
+<section id="section-1">
+  <a id="item-1" class="item" href="">
+      <h2>1</h2>
+  </a>
+
+  <a id="item-2"  class="item" href="">
+      <h2>2</h2>
+  </a>
+</section>
+
+<section id="section-2" data-lrud-consider-container-distance>
+  <section>
+    <a id="item-3" class="item" href="">
+        <h2>3</h2>
+    </a>
+    <a id="item-4" class="item" href="">
+        <h2>4</h2>
+    </a>
+    <a id="item-5" class="item" href="">
+        <h2>5</h2>
+    </a>
+  </section>
+
+  <section>
+    <a id="item-6" class="item" href="">
+        <h2>6</h2>
+    </a>
+    <a id="item-7" class="item" href="">
+        <h2>7</h2>
+    </a>
+    <a id="item-8" class="item" href="">
+        <h2>8</h2>
+    </a>
+  </section>
+
+</section>
+
+<section id="section-3">
+  <a id="item-9" class="item" href="">
+    <h2>9</h2>
+  </a>
+  
+  <a id="item-10"  class="item" href="">
+    <h2>10</h2>
+  </a>
+</section>
+
+<section id="section-2" data-lrud-consider-container-distance>
+  <section style="margin-top: 0px">
+    <a id="item-11" class="item" href="" style="margin-top: 0px">
+        <h2>11</h2>
+    </a>
+  </section>
+  <section>
+    <a id="item-12" class="item" href="">
+        <h2>12</h2>
+    </a>
+  </section>
+</section>

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -661,6 +661,23 @@ describe('LRUD spatial', () => {
 
       expect(result).toEqual('item-7');
     });
+
+    it('should remember the last active child of a focusable container', async () => {
+      await page.goto(`${testPath}/4c-v-5f-nested.html`);
+      await page.waitForFunction('document.activeElement');
+      await page.evaluate(() => document.getElementById('section-2').setAttribute('data-lrud-consider-container-distance', true));
+      await page.evaluate(() => document.getElementById('item-4').focus());
+      await page.keyboard.press('ArrowRight');
+      let result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-5');
+      await page.evaluate(() => document.getElementById('item-7').focus());
+      await page.keyboard.press('ArrowUp');
+      result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-5');
+      await page.evaluate(() => document.getElementById('item-4').focus());
+      await page.keyboard.press('ArrowUp');
+      expect(await page.evaluate(() => document.getElementById('section-2').getAttribute('data-focus'))).toBe('item-4');
+    });
   });
 
   describe('Last active child', () => {

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -662,6 +662,19 @@ describe('LRUD spatial', () => {
       expect(result).toEqual('item-7');
     });
 
+    it('should not set data-focus attributes to a container ID', async () => {
+      await page.goto(`${testPath}/focusable-container-with-empty-space.html`);
+      // makes section-2 the best candidate, although it will later be ignored
+      await page.evaluate(() => document.getElementById('section-2').setAttribute('data-lrud-overlap-threshold', 1));
+      await page.evaluate(() => document.getElementById('item-6').focus());
+      await page.keyboard.press('ArrowLeft');
+
+      const result = await page.evaluate(() => document.activeElement.id);
+
+      expect(await page.evaluate(() => document.getElementById('section-2').getAttribute('data-focus'))).toBe('item-6');
+      expect(result).toEqual('item-6');
+    });
+
     it('should remember the last active child of a focusable container', async () => {
       await page.goto(`${testPath}/nested-focusable-containers.html`);
       await page.waitForFunction('document.activeElement');

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -663,20 +663,36 @@ describe('LRUD spatial', () => {
     });
 
     it('should remember the last active child of a focusable container', async () => {
-      await page.goto(`${testPath}/4c-v-5f-nested.html`);
+      await page.goto(`${testPath}/nested-focusable-containers.html`);
       await page.waitForFunction('document.activeElement');
-      await page.evaluate(() => document.getElementById('section-2').setAttribute('data-lrud-consider-container-distance', true));
-      await page.evaluate(() => document.getElementById('item-4').focus());
+      await page.evaluate(() => document.getElementById('item-3').focus());
       await page.keyboard.press('ArrowRight');
       let result = await page.evaluate(() => document.activeElement.id);
-      expect(result).toEqual('item-5');
-      await page.evaluate(() => document.getElementById('item-7').focus());
+      expect(result).toEqual('item-4');
+      await page.evaluate(() => document.getElementById('item-9').focus());
       await page.keyboard.press('ArrowUp');
       result = await page.evaluate(() => document.activeElement.id);
-      expect(result).toEqual('item-5');
-      await page.evaluate(() => document.getElementById('item-4').focus());
+      expect(result).toEqual('item-4');
+      await page.evaluate(() => document.getElementById('item-5').focus());
       await page.keyboard.press('ArrowUp');
-      expect(await page.evaluate(() => document.getElementById('section-2').getAttribute('data-focus'))).toBe('item-4');
+      result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-1');
+      await page.keyboard.press('ArrowDown');
+      result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-5');
+    });
+
+    it('should prioritise focusable containers that are the same distance away as a regular focusable', async () => {
+      await page.goto(`${testPath}/nested-focusable-containers.html`);
+      await page.waitForFunction('document.activeElement');
+      await page.evaluate(() => document.getElementById('item-11').focus());
+      await page.keyboard.press('ArrowDown');
+      let result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-12');
+      await page.evaluate(() => document.getElementById('item-9').focus());
+      await page.keyboard.press('ArrowDown');
+      result = await page.evaluate(() => document.activeElement.id);
+      expect(result).toEqual('item-12');
     });
   });
 


### PR DESCRIPTION
## Description
Refactor how we set data focus, so that when you move into a focusable container it sets the data-focus of that focusable container to also point to the same item your focus eventually landed on.

Rewrote the README a bit for clarity too

## Motivation and Context
When moving between multiple nested containers, you previously could end up with lots of different data-focuses at each level that you move through. This'd sometimes mean if you moved your focus out of a focusable container then back in via the same thing, you'd lose the focus history because it hadn't been stored on the parent.

## How Has This Been Tested?
New unit tests, and has been running in test for a while now.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
