### PR TITLE
Correct tabindex case and ensure fallback '0' is string

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -80,7 +80,7 @@ const getFocusables = (scope) => {
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
-    .filter(node => parseInt(node.getAttribute('tabIndex') || 0, 10) > -1);
+    .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
 };
 
 /**


### PR DESCRIPTION

## Description
Syntax corrections for `tabindex`

## Motivation and Context
Ensures correct case for `tabindex` and ensures the `0` being used as a fallback in `parseInt` is always a string.

## How Has This Been Tested?
Existing unit tests

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
