### PR TITLE
Use consistent BBC definition of focusableSelector 

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -15,7 +15,7 @@
  */
 
 // Any "interactive content" https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Interactive_content
-const focusableSelector = '[tabindex], a, input, button';
+const focusableSelector = '[tabindex]:not([tabindex^="-"]), a:not([tabindex^="-"]), input:not([tabindex^="-"]), button:not([tabindex^="-"])';
 const containerSelector = 'nav, section, .lrud-container';
 const focusableContainerSelector = '[data-lrud-consider-container-distance]';
 const ignoredClass = 'lrud-ignore';
@@ -79,8 +79,7 @@ const getFocusables = (scope) => {
   if (scope.className.indexOf(ignoredClass) > -1) ignoredElements.push(scope);
 
   return toArray(scope.querySelectorAll(focusableSelector))
-    .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
-    .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
+    .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)));
 };
 
 /**


### PR DESCRIPTION

## Description
Use focusableSelector as per other BBC definitions

## Motivation and Context
For consistency, use the same definition of what is focusable
No change in functionality

## How Has This Been Tested?
Existing tests pass

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
