### PR TITLE
Prevent `disabled` elements being focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Any potential candidate with the `lrud-ignore` class, or inside any parent with 
 
 Focusables with a `tabindex="-1"` attribute will be skipped over, however any focusable inside any parent with `tabindex="-1"` will still be considered focusable.
 
-Potential candidates with aria-disabled='true' will not be considered focusable.
+Potential candidates with `disabled` or `aria-disabled="true"` attributes will not be considered focusable.
 
 ### Focusable Overlap
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Any potential candidate with the `lrud-ignore` class, or inside any parent with 
 
 Focusables with a `tabindex="-1"` attribute will be skipped over, however any focusable inside any parent with `tabindex="-1"` will still be considered focusable.
 
+Potential candidates with aria-disabled='true' will not be considered focusable.
+
 ### Focusable Overlap
 
 By default, LRUD will measure to all candidates that are in the direction to move. It will also include candidates that overlap the current focus by up to 30%, allowing for e.g. a 'right' movement to include something that is above the current focus, but has half of it's size expanding to the right.

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -76,7 +76,6 @@ const getFocusables = (scope) => {
   if (!scope) return [];
 
   const ignoredElements = toArray(scope.querySelectorAll(ignoreSelector));
-  if (matches(scope, ignoreSelector)) ignoredElements.push(scope);
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -80,7 +80,7 @@ const getFocusables = (scope) => {
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
-    .filter(node => !(node.getAttribute('aria-disabled')=='true'))
+    .filter(node => !(node.getAttribute('aria-disabled') == 'true'))
     .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
 };
 

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -76,7 +76,7 @@ const getFocusables = (scope) => {
   if (!scope) return [];
 
   const ignoredElements = toArray(scope.querySelectorAll(ignoreSelector));
-  if (scope.className.indexOf(ignoreSelector) > -1) ignoredElements.push(scope);
+  if (matches(scope, ignoreSelector)) ignoredElements.push(scope);
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -80,6 +80,7 @@ const getFocusables = (scope) => {
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
+    .filter(node => !(node.getAttribute('aria-disabled')=='true'))
     .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
 };
 

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -80,6 +80,7 @@ const getFocusables = (scope) => {
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
+    .filter(node => node.getAttribute('disabled') == null)
     .filter(node => !(node.getAttribute('aria-disabled') == 'true'))
     .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
 };

--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -18,7 +18,7 @@
 const focusableSelector = '[tabindex], a, input, button';
 const containerSelector = 'nav, section, .lrud-container';
 const focusableContainerSelector = '[data-lrud-consider-container-distance]';
-const ignoredClass = 'lrud-ignore';
+const ignoreSelector = '.lrud-ignore, [disabled], [aria-disabled="true"]';
 
 /**
  * Element API .matches() with fallbacks
@@ -75,13 +75,11 @@ const getParentContainer = (elem) => {
 const getFocusables = (scope) => {
   if (!scope) return [];
 
-  const ignoredElements = toArray(scope.querySelectorAll('.' + ignoredClass));
-  if (scope.className.indexOf(ignoredClass) > -1) ignoredElements.push(scope);
+  const ignoredElements = toArray(scope.querySelectorAll(ignoreSelector));
+  if (scope.className.indexOf(ignoreSelector) > -1) ignoredElements.push(scope);
 
   return toArray(scope.querySelectorAll(focusableSelector))
     .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
-    .filter(node => node.getAttribute('disabled') == null)
-    .filter(node => !(node.getAttribute('aria-disabled') == 'true'))
     .filter(node => parseInt(node.getAttribute('tabindex') || '0', 10) > -1);
 };
 

--- a/test/layouts/disabled.html
+++ b/test/layouts/disabled.html
@@ -1,0 +1,33 @@
+<h1>Test file with disabled, and aria-disabled elements</h1>
+
+<section>
+  <a id="item-1" class="item" href="">
+      <h2>1</h2>
+  </a>
+  
+  <a id="item-2" disabled class="item" href="">
+      <h2>2</h2>
+  </a>
+  
+  <a id="item-3" class="item" href="">
+      <h2>3</h2>
+  </a>
+  
+  <a id="item-4" class="item" href="">
+      <h2>4</h2>
+  </a>
+</section>
+
+<section>
+  <a id="item-5" class="item" href="">
+      <h2>5</h2>
+  </a>
+  
+  <a id="item-6" aria-disabled="true" class="item" href="">
+      <h2>6</h2>
+  </a>
+  
+  <a id="item-7" class="item" href="">
+      <h2>7</h2>
+  </a>
+</section>

--- a/test/layouts/hidden.html
+++ b/test/layouts/hidden.html
@@ -16,25 +16,33 @@
     <h2>4</h2>
 </a>
 
-<a id="item-5" class="item lrud-ignore" href="">
+<a id="item-5"  class="item" href="">
     <h2>5</h2>
 </a>
 
-<a id="item-6" class="item" href="">
+<a id="item-6" aria-disabled="true" class="item" href="">
     <h2>6</h2>
 </a>
 
+<a id="item-7" class="item lrud-ignore" href="">
+    <h2>7</h2>
+</a>
+
+<a id="item-8" class="item" href="">
+    <h2>8</h2>
+</a>
+
 <section class="lrud-ignore">
-    <a id="item-7" class="item" href="">
-        <h2>7</h2>
+    <a id="item-9" class="item" href="">
+        <h2>9</h2>
     </a>
 
-    <a id="item-8" class="item" href="">
-        <h2>8</h2>
+    <a id="item-10" class="item" href="">
+        <h2>10</h2>
     </a>
 </section>
 
-<a id="item-9" class="item" href="">
-    <h2>9</h2>
+<a id="item-11" class="item" href="">
+    <h2>11</h2>
 </a>
 

--- a/test/layouts/hidden.html
+++ b/test/layouts/hidden.html
@@ -16,33 +16,25 @@
     <h2>4</h2>
 </a>
 
-<a id="item-5"  class="item" href="">
+<a id="item-5" class="item lrud-ignore" href="">
     <h2>5</h2>
 </a>
 
-<a id="item-6" aria-disabled="true" class="item" href="">
+<a id="item-6" class="item" href="">
     <h2>6</h2>
 </a>
 
-<a id="item-7" class="item lrud-ignore" href="">
-    <h2>7</h2>
-</a>
-
-<a id="item-8" class="item" href="">
-    <h2>8</h2>
-</a>
-
 <section class="lrud-ignore">
-    <a id="item-9" class="item" href="">
-        <h2>9</h2>
+    <a id="item-7" class="item" href="">
+        <h2>7</h2>
     </a>
 
-    <a id="item-10" class="item" href="">
-        <h2>10</h2>
+    <a id="item-8" class="item" href="">
+        <h2>8</h2>
     </a>
 </section>
 
-<a id="item-11" class="item" href="">
-    <h2>11</h2>
+<a id="item-9" class="item" href="">
+    <h2>9</h2>
 </a>
 

--- a/test/layouts/styles.css
+++ b/test/layouts/styles.css
@@ -70,6 +70,11 @@ section.panel, div.panel {
     display: none;
 }
 
+[aria-disabled="true"] {
+    background: repeating-linear-gradient(135deg, #e2feff55, #d3d3d355 10px, #94baffbb 10px, #d3d3d3bb 20px);
+    font-style: italic;
+}
+
 .lrud-ignore {
     background: repeating-linear-gradient(45deg, #d3d3d355, #d3d3d355 10px, #d3d3d3bb 10px, #d3d3d3bb 20px);
     font-style: italic;

--- a/test/layouts/styles.css
+++ b/test/layouts/styles.css
@@ -71,7 +71,7 @@ section.panel, div.panel {
 }
 
 [aria-disabled="true"] {
-    background: repeating-linear-gradient(135deg, #e2feff55, #d3d3d355 10px, #94baffbb 10px, #d3d3d3bb 20px);
+    background: repeating-linear-gradient(135deg, #d3d3d355, #d3d3d355 10px, #94baffbb 10px, #94baffbb 20px);
     font-style: italic;
 }
 

--- a/test/layouts/styles.css
+++ b/test/layouts/styles.css
@@ -70,6 +70,10 @@ section.panel, div.panel {
     display: none;
 }
 
+[disabled] {
+    background: repeating-linear-gradient(135deg, #d3d3d355, #d3d3d355 10px, #c08181bb 10px, #c08181bb 20px);
+    font-style: italic;
+}
 [aria-disabled="true"] {
     background: repeating-linear-gradient(135deg, #d3d3d355, #d3d3d355 10px, #94baffbb 10px, #94baffbb 20px);
     font-style: italic;

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -325,6 +325,19 @@ describe('LRUD spatial', () => {
     });
   });
 
+  describe('disabled elements are not focusable', () => {
+    it('aria-disabled="true"', async () => {
+      await page.goto(`${testPath}/disabled.html`);
+      await page.waitForFunction('document.activeElement');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowRight');
+
+      const result = await page.evaluate(() => document.activeElement.id);
+
+      expect(result).toEqual('item-7');
+    });
+  });
+
   describe('Page with 11 candidates, with varying sizes', () => {
     it('should focus on candidate 6 when right, down is pressed', async () => {
       await page.goto(`${testPath}/0c-v-11f-size.html`);

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -326,6 +326,16 @@ describe('LRUD spatial', () => {
   });
 
   describe('disabled elements are not focusable', () => {
+    it('disabled', async () => {
+      await page.goto(`${testPath}/disabled.html`);
+      await page.waitForFunction('document.activeElement');
+      await page.keyboard.press('ArrowRight');
+
+      const result = await page.evaluate(() => document.activeElement.id);
+
+      expect(result).toEqual('item-3');
+    });
+
     it('aria-disabled="true"', async () => {
       await page.goto(`${testPath}/disabled.html`);
       await page.waitForFunction('document.activeElement');


### PR DESCRIPTION
## Description
Add a new filter to filter out elements with `disabled` or  `aria-disabled="true"` 

## Motivation and Context
Fixes: #51 

## How Has This Been Tested?
Add new tests to ensure potential focusables which have `disabled` or `aria-disabled="true"` attribute aren't focusable.
Add a new test layout to cover these cases.
Add a new colour combo to show `disabled` and `aria-disabled="true"`

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
