### PR TITLE
BUG FIX: lrud-ignore being ignored

### DIFF
--- a/lib/lrud.js
+++ b/lib/lrud.js
@@ -89,10 +89,16 @@ const getFocusables = (scope) => {
  * @param {HTMLElement} scope The element to search inside of
  * @return {HTMLElement[]} Array of valid focusables inside the scope
  */
-const getAllFocusables = (scope) => [
-  ...toArray(scope.querySelectorAll(focusableContainerSelector)).filter(container => getFocusables(container)?.length > 0),
-  ...getFocusables(scope)
-];
+const getAllFocusables = (scope) => {
+  const ignoredElements = toArray(scope.querySelectorAll(ignoreSelector));
+
+    return [
+    ...toArray(scope.querySelectorAll(focusableContainerSelector))
+      .filter(node => !ignoredElements.some(ignored => ignored == node || ignored.contains(node)))
+      .filter(container => getFocusables(container)?.length > 0),
+    ...getFocusables(scope)
+  ];
+};
 
 /**
  * Build an array of ancestor containers


### PR DESCRIPTION
## Description
Added a filter to `getAllFocusables` to filter out the ignored elements. 
## Motivation and Context
Bug Introduced: #44 

## How Has This Been Tested?
New unit test to check `getAllFocusables` filters out ignored candidates.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
